### PR TITLE
Configure release signing via environment variables (issue #35)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,18 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            storeFile = file(System.getenv("KEYSTORE_PATH") ?: "release.keystore")
+            storePassword = System.getenv("KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("KEY_ALIAS")
+            keyPassword = System.getenv("KEY_PASSWORD")
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),


### PR DESCRIPTION
- Add signingConfigs.release reading KEYSTORE_PATH, KEYSTORE_PASSWORD, KEY_ALIAS, KEY_PASSWORD from env (injected by GitHub Actions secrets)
- Wire signingConfig into release buildType
- CI workflow and .gitignore already in place