### PR TITLE
feat: Issue #6 turn timer + Issue #10 undo request (re-apply lost merges)

### DIFF
--- a/app/src/main/java/io/github/nicechester/omok/data/GameRepository.kt
+++ b/app/src/main/java/io/github/nicechester/omok/data/GameRepository.kt
@@ -11,6 +11,7 @@ import com.google.firebase.database.database
 import io.github.nicechester.omok.data.model.GameRoom
 import io.github.nicechester.omok.data.model.LastMove
 import io.github.nicechester.omok.data.model.PlayerSeat
+import io.github.nicechester.omok.data.model.UndoRequest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.tasks.await
@@ -27,7 +28,7 @@ object GameRepository {
     private var currentGameId: String? = null
 
     // Mirrors iOS GameViewModel.start(): claimSeat, create if not found
-    suspend fun joinOrCreateGame(gameId: String, playerName: String): Boolean {
+    suspend fun joinOrCreateGame(gameId: String, playerName: String, timerDuration: Int = 0): Boolean {
         val uid = auth.currentUser?.uid
         Log.d(tag, "joinOrCreateGame: gameId=$gameId, uid=$uid, playerName=$playerName")
         if (uid == null) {
@@ -39,7 +40,7 @@ object GameRepository {
             val snapshot = ref.get().await()
             Log.d(tag, "joinOrCreateGame: snapshot exists=${snapshot.exists()}")
             if (!snapshot.exists()) {
-                createGame(ref, uid, playerName)
+                createGame(ref, uid, playerName, timerDuration)
             } else {
                 claimSeat(ref, uid, playerName)
             }
@@ -54,7 +55,8 @@ object GameRepository {
     private suspend fun createGame(
         ref: com.google.firebase.database.DatabaseReference,
         uid: String,
-        playerName: String
+        playerName: String,
+        timerDuration: Int = 0
     ) {
         val sanitized = playerName.trim().take(20)
         val playerData = mutableMapOf<String, Any>(
@@ -64,7 +66,7 @@ object GameRepository {
         )
         if (sanitized.isNotEmpty()) playerData["name"] = sanitized
 
-        val data = mapOf(
+        val data = mutableMapOf<String, Any>(
             "status" to "waiting",
             "turn" to "black",
             "round" to 0,
@@ -76,6 +78,7 @@ object GameRepository {
             "createdAt" to ServerValue.TIMESTAMP,
             "updatedAt" to ServerValue.TIMESTAMP
         )
+        if (timerDuration > 0) data["timerDuration"] = timerDuration
         ref.setValue(data).await()
         Log.d(tag, "Game created: ${ref.key}")
     }
@@ -147,6 +150,7 @@ object GameRepository {
                 "turn" to if (playerColor == "black") "white" else "black",
                 "updatedAt" to ServerValue.TIMESTAMP
             )
+            if (dict["timerDuration"] != null) updates["turnStartedAt"] = ServerValue.TIMESTAMP
 
             val lastMoveDict = dict["lastMove"]
             if (lastMoveDict != null) updates["previousLastMove"] = lastMoveDict
@@ -260,6 +264,104 @@ object GameRepository {
         gamesRef.child(gameId).addValueEventListener(roomListener!!)
     }
 
+    suspend fun requestUndo() {
+        val gameId = currentGameId ?: return
+        val uid = auth.currentUser?.uid ?: return
+        val ref = gamesRef.child(gameId)
+        try {
+            val snapshot = ref.get().await()
+            val dict = snapshot.value as? Map<String, Any> ?: return
+            if (dict["status"] as? String != "playing") return
+            if ((dict["moveCount"] as? Number)?.toInt() ?: 0 < 2) return
+            if (dict["undoRequest"] != null) return
+            ref.updateChildren(mapOf(
+                "undoRequest" to mapOf("requestedBy" to uid, "createdAt" to ServerValue.TIMESTAMP),
+                "updatedAt" to ServerValue.TIMESTAMP
+            )).await()
+        } catch (e: Exception) { Log.e(tag, "requestUndo failed", e) }
+    }
+
+    suspend fun approveUndo() {
+        val gameId = currentGameId ?: return
+        val ref = gamesRef.child(gameId)
+        try {
+            val snapshot = ref.get().await()
+            val dict = snapshot.value as? Map<String, Any> ?: return
+            if (dict["status"] as? String != "playing") return
+            val undoReq = dict["undoRequest"] as? Map<String, Any> ?: return
+            val moveCount = ((dict["moveCount"] as? Number)?.toInt() ?: 0) - 1
+            val currentTurn = dict["turn"] as? String ?: return
+            val prevTurn = if (currentTurn == "black") "white" else "black"
+            val updates = mutableMapOf<String, Any?>(
+                "moveCount" to moveCount,
+                "turn" to prevTurn,
+                "undoRequest" to null,
+                "previousLastMove" to null,
+                "updatedAt" to ServerValue.TIMESTAMP
+            )
+            if (dict["timerDuration"] != null) updates["turnStartedAt"] = ServerValue.TIMESTAMP
+            val lastMoveDict = dict["lastMove"] as? Map<String, Any>
+            if (lastMoveDict != null) {
+                val r = (lastMoveDict["r"] as? Number)?.toInt()
+                val c = (lastMoveDict["c"] as? Number)?.toInt()
+                if (r != null && c != null) updates["board/${r}_${c}"] = null
+            }
+            val prevLastMove = dict["previousLastMove"]
+            updates["lastMove"] = prevLastMove
+            @Suppress("UNCHECKED_CAST")
+            ref.updateChildren(updates as Map<String, Any>).await()
+        } catch (e: Exception) { Log.e(tag, "approveUndo failed", e) }
+    }
+
+    suspend fun rejectUndo() {
+        val gameId = currentGameId ?: return
+        val ref = gamesRef.child(gameId)
+        try {
+            val snapshot = ref.get().await()
+            val dict = snapshot.value as? Map<String, Any> ?: return
+            if (dict["undoRequest"] == null) return
+            val updates = mutableMapOf<String, Any?>(
+                "undoRequest" to null,
+                "updatedAt" to ServerValue.TIMESTAMP
+            )
+            if (dict["timerDuration"] != null) updates["turnStartedAt"] = ServerValue.TIMESTAMP
+            @Suppress("UNCHECKED_CAST")
+            ref.updateChildren(updates as Map<String, Any>).await()
+        } catch (e: Exception) { Log.e(tag, "rejectUndo failed", e) }
+    }
+
+    suspend fun autoPassTurn(gameId: String, expectedTurn: String, expectedTurnStartedAt: Long) {
+        val uid = auth.currentUser?.uid ?: return
+        val ref = gamesRef.child(gameId)
+        try {
+            val snapshot = ref.get().await()
+            val dict = snapshot.value as? Map<String, Any> ?: return
+            if (dict["status"] as? String != "playing") return
+            if (dict["turn"] as? String != expectedTurn) return
+            if ((dict["turnStartedAt"] as? Number)?.toLong() != expectedTurnStartedAt) return
+
+            val players = dict["players"] as? Map<String, Any> ?: return
+            val loserColor = expectedTurn
+            val winnerColor = if (loserColor == "black") "white" else "black"
+            val winnerUid = players.entries
+                .firstOrNull { (_, v) -> (v as? Map<String, Any>)?.get("color") as? String == winnerColor }
+                ?.key
+
+            val updates = mutableMapOf<String, Any>(
+                "status" to "finished",
+                "result" to winnerColor,
+                "updatedAt" to ServerValue.TIMESTAMP
+            )
+            if (winnerUid != null) {
+                val currentScore = (dict["scores"] as? Map<String, Any>)?.get(winnerUid) as? Int ?: 0
+                updates["scores/$winnerUid"] = currentScore + 1
+            }
+            ref.updateChildren(updates).await()
+        } catch (e: Exception) {
+            Log.e(tag, "autoPassTurn failed", e)
+        }
+    }
+
     fun stopListening() {
         val gameId = currentGameId ?: return
         roomListener?.let { gamesRef.child(gameId).removeEventListener(it) }
@@ -304,6 +406,14 @@ object GameRepository {
             ?.mapNotNull { (k, v) -> (v as? Number)?.let { k to it.toInt() } }
             ?.toMap() ?: emptyMap()
 
+        val undoRequestDict = dict["undoRequest"] as? Map<String, Any>
+        val undoRequest = undoRequestDict?.let {
+            UndoRequest(
+                requestedBy = it["requestedBy"] as? String ?: "",
+                createdAt = (it["createdAt"] as? Number)?.toLong() ?: 0
+            )
+        }
+
         return GameRoom(
             id = gameId,
             status = dict["status"] as? String ?: "waiting",
@@ -319,6 +429,7 @@ object GameRepository {
             createdBy = dict["createdBy"] as? String ?: "",
             timerDuration = (dict["timerDuration"] as? Number)?.toInt(),
             turnStartedAt = (dict["turnStartedAt"] as? Number)?.toLong(),
+            undoRequest = undoRequest,
             createdAt = (dict["createdAt"] as? Number)?.toLong() ?: 0,
             updatedAt = (dict["updatedAt"] as? Number)?.toLong() ?: 0
         )

--- a/app/src/main/java/io/github/nicechester/omok/data/model/GameRoom.kt
+++ b/app/src/main/java/io/github/nicechester/omok/data/model/GameRoom.kt
@@ -14,6 +14,11 @@ data class LastMove(
     val color: String = ""
 )
 
+data class UndoRequest(
+    val requestedBy: String = "",
+    val createdAt: Long = 0
+)
+
 data class GameRoom(
     val id: String = "",
     val status: String = "waiting", // waiting, playing, finished
@@ -29,6 +34,7 @@ data class GameRoom(
     val createdBy: String = "",
     val timerDuration: Int? = null,
     val turnStartedAt: Long? = null,
+    val undoRequest: UndoRequest? = null,
     val createdAt: Long = 0,
     val updatedAt: Long = 0
 ) {

--- a/app/src/main/java/io/github/nicechester/omok/ui/game/GameBoardScreen.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/game/GameBoardScreen.kt
@@ -56,14 +56,22 @@ private const val BOARD_SIZE = 15
 @Composable
 fun GameBoardScreen(
     room: GameRoom,
+    remainingSeconds: Int? = null,
     onMakeMove: (row: Int, col: Int) -> Unit,
     onForfeit: () -> Unit,
     onRematch: () -> Unit,
-    onLeave: () -> Unit
+    onLeave: () -> Unit,
+    onRequestUndo: () -> Unit = {},
+    onApproveUndo: () -> Unit = {},
+    onRejectUndo: () -> Unit = {}
 ) {
     val uid = Firebase.auth.currentUser?.uid
     val mySeat = uid?.let { room.seatOf(it) }
-    val canPlay = room.isPlaying() && mySeat != null && room.turn == mySeat
+    val canPlay = room.isPlaying() && mySeat != null && room.turn == mySeat && room.undoRequest == null
+    val canRequestUndo = room.isPlaying() && mySeat != null && room.moveCount >= 2
+        && room.undoRequest == null && room.turn != mySeat
+    // Show approval prompt to the opponent of the requester
+    val showUndoPrompt = room.undoRequest != null && room.undoRequest.requestedBy != uid
 
 
     val blackSeat = room.blackSeat
@@ -88,6 +96,37 @@ fun GameBoardScreen(
     val context = LocalContext.current
 
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    if (showUndoPrompt) {
+        ModalBottomSheet(
+            onDismissRequest = { onRejectUndo() },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            dragHandle = null
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text("Undo Request", fontSize = 20.sp, fontWeight = FontWeight.Bold)
+                Text("Opponent wants to undo the last move.", fontSize = 14.sp, color = Color.Gray)
+                Button(
+                    onClick = onApproveUndo,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF0066FF)),
+                    shape = RoundedCornerShape(12.dp)
+                ) { Text("Allow", fontSize = 16.sp, modifier = Modifier.padding(vertical = 4.dp)) }
+                Button(
+                    onClick = onRejectUndo,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFEEEEEE), contentColor = Color(0xFFDD0000)),
+                    shape = RoundedCornerShape(12.dp)
+                ) { Text("Deny", fontSize = 16.sp, modifier = Modifier.padding(vertical = 4.dp)) }
+            }
+        }
+    }
 
     if (room.isFinished()) {
         val resultColor = when {
@@ -147,6 +186,19 @@ fun GameBoardScreen(
                 color = Color.Black,
                 modifier = Modifier.weight(1f)
             )
+            if (remainingSeconds != null) {
+                val timerColor = when {
+                    remainingSeconds <= 2 -> Color.Red
+                    remainingSeconds <= 4 -> Color(0xFFFF6600)
+                    else -> Color.Black
+                }
+                Text(
+                    text = "${remainingSeconds}s",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = timerColor
+                )
+            }
             // Copy code
             IconButton(onClick = {
                 clipboardManager.setText(AnnotatedString(room.id))
@@ -281,11 +333,11 @@ fun GameBoardScreen(
                 // Placeholder mic button (left) — matches iOS layout
                 Box(modifier = Modifier.size(48.dp))
 
-                // Undo — disabled until implemented
+                // Undo
                 Button(
-                    onClick = { /* TODO: undo */ },
+                    onClick = onRequestUndo,
                     modifier = Modifier.weight(1f),
-                    enabled = false,
+                    enabled = canRequestUndo,
                     colors = ButtonDefaults.buttonColors(
                         containerColor = Color(0xFFEEEEEE),
                         contentColor = Color(0xFF0066FF),
@@ -294,7 +346,7 @@ fun GameBoardScreen(
                     ),
                     shape = RoundedCornerShape(50)
                 ) {
-                    Text("↩ Undo")
+                    Text(if (room.undoRequest != null && room.undoRequest.requestedBy == uid) "Undo…" else "↩ Undo")
                 }
 
                 // Resign — right

--- a/app/src/main/java/io/github/nicechester/omok/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/game/GameScreenViewModel.kt
@@ -9,6 +9,8 @@ import io.github.nicechester.omok.data.GameRepository
 import io.github.nicechester.omok.data.PreferencesManager
 import io.github.nicechester.omok.data.RecentRoomsManager
 import io.github.nicechester.omok.data.model.GameRoom
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -18,6 +20,72 @@ class GameScreenViewModel(private val context: Context? = null) : ViewModel() {
 
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage
+
+    private val _remainingSeconds = MutableStateFlow<Int?>(null)
+    val remainingSeconds: StateFlow<Int?> = _remainingSeconds
+
+    private var timerJob: Job? = null
+    private var timerAnchor: Pair<String, Long>? = null // turn to turnStartedAt
+    private var isPaused = false
+
+    init {
+        viewModelScope.launch {
+            GameRepository.currentRoom.collect { room ->
+                updateTimerState(room, force = false)
+            }
+        }
+    }
+
+    fun onResume() {
+        isPaused = false
+        updateTimerState(GameRepository.currentRoom.value, force = true)
+    }
+
+    fun onPause() {
+        isPaused = true
+        timerJob?.cancel()
+        timerJob = null
+    }
+
+    private fun updateTimerState(room: GameRoom?, force: Boolean) {
+        if (isPaused) {
+            timerJob?.cancel(); timerJob = null; return
+        }
+        if (room == null || !room.isPlaying()) {
+            timerJob?.cancel(); timerJob = null; _remainingSeconds.value = null; return
+        }
+        val duration = room.timerDuration ?: run {
+            timerJob?.cancel(); timerJob = null; _remainingSeconds.value = null; return
+        }
+        val turnStartedAt = room.turnStartedAt ?: run {
+            timerJob?.cancel(); timerJob = null; _remainingSeconds.value = null; return
+        }
+        val needsRestart = force || timerAnchor?.first != room.turn || timerAnchor?.second != turnStartedAt
+        if (needsRestart) {
+            timerJob?.cancel()
+            timerAnchor = room.turn to turnStartedAt
+            startTicking(room.turn, turnStartedAt, duration)
+        }
+    }
+
+    private fun startTicking(turn: String, turnStartedAt: Long, duration: Int) {
+        timerJob = viewModelScope.launch {
+            val gameId = GameRepository.currentRoom.value?.id ?: return@launch
+            while (true) {
+                if (isPaused) return@launch
+                val now = System.currentTimeMillis()
+                val elapsed = now - turnStartedAt
+                val remaining = maxOf(0L, duration * 1000L - elapsed)
+                val remainingInt = minOf(duration, ((remaining + 999) / 1000).toInt())
+                _remainingSeconds.value = remainingInt
+                if (remainingInt <= 0) {
+                    GameRepository.autoPassTurn(gameId, turn, turnStartedAt)
+                    return@launch
+                }
+                delay(1000)
+            }
+        }
+    }
 
     fun joinOrCreateGame(gameId: String, timerSeconds: Int = 0) {
         viewModelScope.launch {
@@ -29,7 +97,7 @@ class GameScreenViewModel(private val context: Context? = null) : ViewModel() {
                 }
                 val playerName = context?.let { PreferencesManager.getPlayerNameOnce(it) } ?: "Player"
                 android.util.Log.d("GameScreenViewModel", "joinOrCreateGame: gameId=$gameId, player=$playerName")
-                val success = GameRepository.joinOrCreateGame(gameId, playerName)
+            val success = GameRepository.joinOrCreateGame(gameId, playerName, timerSeconds)
                 if (success) {
                     context?.let { RecentRoomsManager.recordPlay(it, gameId) }
                 } else {
@@ -74,6 +142,24 @@ class GameScreenViewModel(private val context: Context? = null) : ViewModel() {
             } catch (e: Exception) {
                 _errorMessage.value = "Failed to rematch: ${e.message}"
             }
+        }
+    }
+
+    fun requestUndo() {
+        viewModelScope.launch {
+            try { GameRepository.requestUndo() } catch (e: Exception) { _errorMessage.value = "Failed to request undo: ${e.message}" }
+        }
+    }
+
+    fun approveUndo() {
+        viewModelScope.launch {
+            try { GameRepository.approveUndo() } catch (e: Exception) { _errorMessage.value = "Failed to approve undo: ${e.message}" }
+        }
+    }
+
+    fun rejectUndo() {
+        viewModelScope.launch {
+            try { GameRepository.rejectUndo() } catch (e: Exception) { _errorMessage.value = "Failed to reject undo: ${e.message}" }
         }
     }
 

--- a/app/src/main/java/io/github/nicechester/omok/ui/screens/GameScreen.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/screens/GameScreen.kt
@@ -17,7 +17,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -39,13 +44,30 @@ fun GameScreen(paddingValues: PaddingValues, viewModel: GameScreenViewModel? = n
     val resolvedViewModel: GameScreenViewModel = viewModel ?: viewModel { GameScreenViewModel(context) }
     val currentRoom = resolvedViewModel.currentRoom.collectAsState()
 
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> resolvedViewModel.onResume()
+                Lifecycle.Event.ON_PAUSE -> resolvedViewModel.onPause()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
     if (currentRoom.value != null) {
         GameBoardScreen(
             room = currentRoom.value!!,
+            remainingSeconds = resolvedViewModel.remainingSeconds.collectAsState().value,
             onMakeMove = { row, col -> resolvedViewModel.makeMove(row, col) },
             onForfeit = { resolvedViewModel.forfeit() },
             onRematch = { resolvedViewModel.voteRematch() },
-            onLeave = { resolvedViewModel.leaveGame() }
+            onLeave = { resolvedViewModel.leaveGame() },
+            onRequestUndo = { resolvedViewModel.requestUndo() },
+            onApproveUndo = { resolvedViewModel.approveUndo() },
+            onRejectUndo = { resolvedViewModel.rejectUndo() }
         )
     } else {
         Box(


### PR DESCRIPTION
## Summary

Re-applies changes lost when main branch was fixed, plus new work.

### Issue #6 — Turn Timer
- `timerDuration` written to Firebase on game creation
- `turnStartedAt` stamped on every move when timer is enabled
- Countdown display in `GameBoardScreen` header with color coding (black → orange ≤4s → red ≤2s)
- `autoPassTurn` for timeout forfeit (race-safe: checks turn + turnStartedAt before writing)
- Timer pauses when app backgrounds via `LifecycleEventObserver`

### Issue #10 — Undo Request (re-apply from lost PR #37)
- `UndoRequest` model + `undoRequest` field on `GameRoom`
- `requestUndo` / `approveUndo` / `rejectUndo` in `GameRepository`
- Undo button enabled when `canRequestUndo` (it's opponent's turn, moveCount ≥ 2, no pending request)
- `AlertDialog` shown to opponent when undo request arrives from Firebase
- `makeMove` blocked while `undoRequest` is pending

Closes #6