### PR TITLE
feat: Implement push notifications for opponent moves (Issue #13)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
     implementation("com.google.firebase:firebase-database-ktx")
     implementation("com.google.firebase:firebase-auth-ktx")
+    implementation("com.google.firebase:firebase-messaging-ktx")
 
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name="io.github.nicechester.omok.OmokApplication"
@@ -26,6 +27,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <service
+            android:name="io.github.nicechester.omok.firebase.OmokFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="omok_turns" />
     </application>
 
 </manifest>

--- a/app/src/main/java/io/github/nicechester/omok/MainActivity.kt
+++ b/app/src/main/java/io/github/nicechester/omok/MainActivity.kt
@@ -1,25 +1,47 @@
 package io.github.nicechester.omok
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import io.github.nicechester.omok.firebase.FirebaseManager
+import io.github.nicechester.omok.firebase.PendingGameNavigation
 import io.github.nicechester.omok.ui.theme.OmokTheme
 import io.github.nicechester.omok.ui.OmokApp
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { /* permission result handled silently */ }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Initialize Firebase (blocking in background)
         lifecycleScope.launch {
             FirebaseManager.initialize()
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+                != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+
+        intent?.getStringExtra("gameId")?.let {
+            PendingGameNavigation.request(it)
         }
 
         setContent {
@@ -31,6 +53,14 @@ class MainActivity : ComponentActivity() {
                     OmokApp()
                 }
             }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        intent.getStringExtra("gameId")?.let {
+            PendingGameNavigation.request(it)
         }
     }
 }

--- a/app/src/main/java/io/github/nicechester/omok/OmokApplication.kt
+++ b/app/src/main/java/io/github/nicechester/omok/OmokApplication.kt
@@ -3,18 +3,31 @@ package io.github.nicechester.omok
 import android.app.Application
 import android.util.Log
 import com.google.firebase.FirebaseApp
+import com.google.firebase.messaging.FirebaseMessaging
 import io.github.nicechester.omok.firebase.FirebaseManager
+import io.github.nicechester.omok.firebase.OmokFirebaseMessagingService
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 class OmokApplication : Application() {
     override fun onCreate() {
         super.onCreate()
         Log.d("OmokApplication", "Initializing Firebase")
         FirebaseApp.initializeApp(this)
+        OmokFirebaseMessagingService.createNotificationChannel(this)
         CoroutineScope(Dispatchers.IO).launch {
             FirebaseManager.initialize()
+            FirebaseManager.isAuthenticated.first { it }
+            try {
+                val token = FirebaseMessaging.getInstance().token.await()
+                Log.d("OmokApplication", "FCM token: $token")
+                OmokFirebaseMessagingService.saveToken(token)
+            } catch (e: Exception) {
+                Log.e("OmokApplication", "FCM token fetch failed: ${e.message}")
+            }
         }
     }
 }

--- a/app/src/main/java/io/github/nicechester/omok/firebase/ActiveGameTracker.kt
+++ b/app/src/main/java/io/github/nicechester/omok/firebase/ActiveGameTracker.kt
@@ -1,0 +1,5 @@
+package io.github.nicechester.omok.firebase
+
+object ActiveGameTracker {
+    @Volatile var activeGameId: String? = null
+}

--- a/app/src/main/java/io/github/nicechester/omok/firebase/OmokFirebaseMessagingService.kt
+++ b/app/src/main/java/io/github/nicechester/omok/firebase/OmokFirebaseMessagingService.kt
@@ -1,0 +1,86 @@
+package io.github.nicechester.omok.firebase
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.google.firebase.Firebase
+import com.google.firebase.auth.auth
+import com.google.firebase.database.database
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import io.github.nicechester.omok.MainActivity
+
+class OmokFirebaseMessagingService : FirebaseMessagingService() {
+
+    override fun onNewToken(token: String) {
+        Log.d("OmokFCM", "onNewToken: $token")
+        saveToken(token)
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        Log.d("OmokFCM", "onMessageReceived: data=${message.data}, notification=${message.notification?.title}")
+        val gameId = message.data["gameId"] ?: return
+        if (ActiveGameTracker.activeGameId == gameId) {
+            Log.d("OmokFCM", "Game already active, suppressing notification")
+            return
+        }
+        val title = message.notification?.title ?: "Your Turn!"
+        val body = message.notification?.body ?: "Opponent made a move"
+        showNotification(gameId, title, body)
+    }
+
+    private fun showNotification(gameId: String, title: String, body: String) {
+        val channelId = "omok_turns"
+        val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        createNotificationChannel(nm, channelId)
+
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("gameId", gameId)
+        }
+        val pi = PendingIntent.getActivity(this, gameId.hashCode(), intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+        val notification = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setContentIntent(pi)
+            .build()
+
+        nm.notify(gameId.hashCode(), notification)
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "omok_turns"
+        private const val CHANNEL_NAME = "Your Turn"
+
+        fun createNotificationChannel(nm: NotificationManager, channelId: String = CHANNEL_ID) {
+            if (nm.getNotificationChannel(channelId) == null) {
+                nm.createNotificationChannel(
+                    NotificationChannel(channelId, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH)
+                )
+            }
+        }
+
+        fun createNotificationChannel(context: Context) {
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            createNotificationChannel(nm, CHANNEL_ID)
+        }
+
+        fun saveToken(token: String) {
+            val uid = Firebase.auth.currentUser?.uid ?: run {
+                Log.w("OmokFCM", "saveToken: no authenticated user")
+                return
+            }
+            Log.d("OmokFCM", "saveToken: uid=$uid")
+            Firebase.database("https://omok-5-in-a-row-default-rtdb.firebaseio.com")
+                .getReference("omok/users/$uid/fcmToken")
+                .setValue(token)
+        }
+    }
+}

--- a/app/src/main/java/io/github/nicechester/omok/firebase/PendingGameNavigation.kt
+++ b/app/src/main/java/io/github/nicechester/omok/firebase/PendingGameNavigation.kt
@@ -1,0 +1,12 @@
+package io.github.nicechester.omok.firebase
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+object PendingGameNavigation {
+    private val _pendingGameId = MutableStateFlow<String?>(null)
+    val pendingGameId: StateFlow<String?> = _pendingGameId
+
+    fun request(gameId: String) { _pendingGameId.value = gameId }
+    fun consume() { _pendingGameId.value = null }
+}

--- a/app/src/main/java/io/github/nicechester/omok/ui/OmokApp.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/OmokApp.kt
@@ -58,7 +58,10 @@ fun OmokApp() {
             },
             bottomBar = { BottomNavBar(navController) }
         ) { paddingValues ->
-            OmokNavHost(navController = navController, paddingValues = paddingValues)
+            OmokNavHost(
+                navController = navController,
+                paddingValues = paddingValues
+            )
         }
     }
 }

--- a/app/src/main/java/io/github/nicechester/omok/ui/navigation/NavHost.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/navigation/NavHost.kt
@@ -2,11 +2,15 @@ package io.github.nicechester.omok.ui.navigation
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import io.github.nicechester.omok.firebase.PendingGameNavigation
 import io.github.nicechester.omok.ui.game.GameScreenViewModel
 import io.github.nicechester.omok.ui.screens.GameScreen
 import io.github.nicechester.omok.ui.screens.RoomsScreen
@@ -19,6 +23,15 @@ fun OmokNavHost(
 ) {
     val context = LocalContext.current
     val gameViewModel: GameScreenViewModel = viewModel { GameScreenViewModel(context) }
+    val pendingGameId by PendingGameNavigation.pendingGameId.collectAsState()
+
+    LaunchedEffect(pendingGameId) {
+        pendingGameId?.let { gameId ->
+            gameViewModel.joinOrCreateGame(gameId)
+            navController.navigate("play") { launchSingleTop = true }
+            PendingGameNavigation.consume()
+        }
+    }
 
     NavHost(
         navController = navController,

--- a/app/src/main/java/io/github/nicechester/omok/ui/screens/GameScreen.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/screens/GameScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.github.nicechester.omok.ui.game.GameBoardScreen
 import io.github.nicechester.omok.ui.game.GameScreenViewModel
+import io.github.nicechester.omok.firebase.ActiveGameTracker
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -69,6 +70,11 @@ fun GameScreen(paddingValues: PaddingValues, viewModel: GameScreenViewModel? = n
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    DisposableEffect(currentRoom.value?.id) {
+        ActiveGameTracker.activeGameId = currentRoom.value?.id
+        onDispose { ActiveGameTracker.activeGameId = null }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {


### PR DESCRIPTION
## Summary
Implements Firebase Cloud Messaging (FCM) push notifications for opponent moves, with proper handling of notification taps to open the correct game room and suppression when the game is already visible.

## Changes
- **OmokFirebaseMessagingService** — New service handling FCM message receipt, notification creation, and token management
- **PendingGameNavigation** — Singleton flow-based state holder for pending game navigation from notification taps
- **MainActivity** — Added `onNewIntent` override to handle notification taps when app process is alive; added runtime permission request for POST_NOTIFICATIONS on Android 13+
- **OmokApplication** — Creates notification channel at startup and fetches FCM token on authentication
- **NavHost** — Observes PendingGameNavigation flow and navigates to the correct room when notification is tapped
- **GameScreen** — Tracks active game via ActiveGameTracker to suppress notifications when game is already visible
- **ActiveGameTracker** — New singleton volatile state holder to detect when a game room is on-screen
- **AndroidManifest.xml** — Added OmokFirebaseMessagingService declaration, POST_NOTIFICATIONS permission, and default channel metadata
- **build.gradle.kts** — Added firebase-messaging-ktx dependency

## Related Issues
Fixes #13

## Testing
- Verify tapping a push notification when app is backgrounded opens the correct game room
- Verify tapping a push notification when app is already open (MainActivity exists) opens the correct room (via onNewIntent)
- Verify no notification is displayed when viewing the game that generated it (foreground suppression)
- Verify notifications appear when viewing a different game room
- Test on Android 13+ to confirm runtime permission prompt appears and notification delivery works after granting

## Notes
- The Cloud Function (omok/functions/index.js) contains a bug in player lookup that was fixed in omok#89 and deployed separately
- iOS has parallel work tracked in omok#90 (Universal Links) and additional improvements in omok#89 (retry logic, duplicate notification dedup)