### PR TITLE
feat: Android App Links for game invite URLs (Issue #42)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,15 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="omok-5-in-a-row.web.app"
+                    android:pathPrefix="/join/" />
+            </intent-filter>
         </activity>
 
         <service

--- a/app/src/main/java/io/github/nicechester/omok/MainActivity.kt
+++ b/app/src/main/java/io/github/nicechester/omok/MainActivity.kt
@@ -40,9 +40,7 @@ class MainActivity : ComponentActivity() {
             requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
         }
 
-        intent?.getStringExtra("gameId")?.let {
-            PendingGameNavigation.request(it)
-        }
+        resolveGameId(intent)?.let { PendingGameNavigation.request(it) }
 
         setContent {
             OmokTheme {
@@ -59,8 +57,15 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        intent.getStringExtra("gameId")?.let {
-            PendingGameNavigation.request(it)
+        resolveGameId(intent)?.let { PendingGameNavigation.request(it) }
+    }
+
+    private fun resolveGameId(intent: Intent?): String? {
+        intent?.data?.let { uri ->
+            if (uri.host == "omok-5-in-a-row.web.app") {
+                return uri.lastPathSegment
+            }
         }
+        return intent?.getStringExtra("gameId")
     }
 }


### PR DESCRIPTION
Closes #42

## Changes

**`omok` repo** (deployed separately via Firebase Hosting):
- `public/.well-known/assetlinks.json` — new file with debug + release SHA-256 fingerprints
- `firebase.json` — added `Content-Type: application/json` header for `assetlinks.json`
- `public/join/index.html` — fallback page now serves Android App Link URL vs iOS custom scheme based on user agent

**`omok-android`**:
- `AndroidManifest.xml` — added `intent-filter` with `android:autoVerify="true"` for `https://omok-5-in-a-row.web.app/join/*`
- `MainActivity` — added `resolveGameId()` to handle both App Link URI (`intent.data`) and FCM extras (`gameId`), feeding into the existing `PendingGameNavigation`

## Verification
```
adb shell pm get-app-links io.github.nicechester.omok
# omok-5-in-a-row.web.app: verified

adb shell am start -a android.intent.action.VIEW \
  -d "https://omok-5-in-a-row.web.app/join/testroom123" \
  io.github.nicechester.omok
# Opens app directly to testroom123 ✓
```