### PR TITLE
feat: In-game emoticon reactions (Issue #45)

### DIFF
--- a/app/src/main/java/io/github/nicechester/omok/data/GameRepository.kt
+++ b/app/src/main/java/io/github/nicechester/omok/data/GameRepository.kt
@@ -11,6 +11,7 @@ import com.google.firebase.database.database
 import io.github.nicechester.omok.data.model.GameRoom
 import io.github.nicechester.omok.data.model.LastMove
 import io.github.nicechester.omok.data.model.PlayerSeat
+import io.github.nicechester.omok.data.model.Reaction
 import io.github.nicechester.omok.data.model.UndoRequest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -251,6 +252,14 @@ object GameRepository {
         }
     }
 
+    suspend fun sendReaction(emoji: String) {
+        val gameId = currentGameId ?: return
+        val uid = auth.currentUser?.uid ?: return
+        gamesRef.child(gameId).child("reaction").setValue(
+            mapOf("from" to uid, "emoji" to emoji, "timestamp" to ServerValue.TIMESTAMP)
+        ).await()
+    }
+
     fun listenToGame(gameId: String) {
         currentGameId = gameId
         roomListener?.let { gamesRef.child(gameId).removeEventListener(it) }
@@ -418,6 +427,15 @@ object GameRepository {
             )
         }
 
+        val reactionDict = dict["reaction"] as? Map<String, Any>
+        val reaction = reactionDict?.let {
+            Reaction(
+                from = it["from"] as? String ?: "",
+                emoji = it["emoji"] as? String ?: "",
+                timestamp = (it["timestamp"] as? Number)?.toLong() ?: 0
+            )
+        }
+
         return GameRoom(
             id = gameId,
             status = dict["status"] as? String ?: "waiting",
@@ -434,6 +452,7 @@ object GameRepository {
             timerDuration = (dict["timerDuration"] as? Number)?.toInt(),
             turnStartedAt = (dict["turnStartedAt"] as? Number)?.toLong(),
             undoRequest = undoRequest,
+            reaction = reaction,
             createdAt = (dict["createdAt"] as? Number)?.toLong() ?: 0,
             updatedAt = (dict["updatedAt"] as? Number)?.toLong() ?: 0
         )

--- a/app/src/main/java/io/github/nicechester/omok/data/model/GameRoom.kt
+++ b/app/src/main/java/io/github/nicechester/omok/data/model/GameRoom.kt
@@ -19,6 +19,12 @@ data class UndoRequest(
     val createdAt: Long = 0
 )
 
+data class Reaction(
+    val from: String = "",
+    val emoji: String = "",
+    val timestamp: Long = 0
+)
+
 data class GameRoom(
     val id: String = "",
     val status: String = "waiting", // waiting, playing, finished
@@ -35,6 +41,7 @@ data class GameRoom(
     val timerDuration: Int? = null,
     val turnStartedAt: Long? = null,
     val undoRequest: UndoRequest? = null,
+    val reaction: Reaction? = null,
     val createdAt: Long = 0,
     val updatedAt: Long = 0
 ) {

--- a/app/src/main/java/io/github/nicechester/omok/ui/game/GameBoardScreen.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/game/GameBoardScreen.kt
@@ -24,12 +24,17 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Logout
 import androidx.compose.material.icons.filled.IosShare
+import androidx.compose.material.icons.filled.SentimentSatisfied
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -63,10 +68,13 @@ fun GameBoardScreen(
     onLeave: () -> Unit,
     onRequestUndo: () -> Unit = {},
     onApproveUndo: () -> Unit = {},
-    onRejectUndo: () -> Unit = {}
+    onRejectUndo: () -> Unit = {},
+    onSendReaction: (String) -> Unit = {},
+    pendingReaction: String? = null
 ) {
     val uid = Firebase.auth.currentUser?.uid
     val mySeat = uid?.let { room.seatOf(it) }
+    var showEmojiTray by remember { mutableStateOf(false) }
     val canPlay = room.isPlaying() && mySeat != null && room.turn == mySeat && room.undoRequest == null
     val canRequestUndo = room.isPlaying() && mySeat != null && room.moveCount >= 2
         && room.undoRequest == null && room.turn != mySeat
@@ -320,7 +328,7 @@ fun GameBoardScreen(
             }
         }
 
-        // Bottom action bar — Undo center, Resign right (matches iOS)
+        // Bottom action bar + emoji tray (matches iOS layout)
         if (!room.isFinished()) {
             Spacer(modifier = Modifier.height(8.dp))
             Row(
@@ -330,10 +338,11 @@ fun GameBoardScreen(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Placeholder mic button (left) — matches iOS layout
-                Box(modifier = Modifier.size(48.dp))
-
-                // Undo
+                Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+                    IconButton(onClick = { showEmojiTray = !showEmojiTray }) {
+                        Icon(Icons.Default.SentimentSatisfied, contentDescription = "React", modifier = Modifier.size(28.dp))
+                    }
+                }
                 Button(
                     onClick = onRequestUndo,
                     modifier = Modifier.weight(1f),
@@ -348,8 +357,6 @@ fun GameBoardScreen(
                 ) {
                     Text(if (room.undoRequest != null && room.undoRequest.requestedBy == uid) "Undo…" else "↩ Undo")
                 }
-
-                // Resign — right
                 Button(
                     onClick = onForfeit,
                     modifier = Modifier.weight(1f),
@@ -362,8 +369,30 @@ fun GameBoardScreen(
                     Text("🚩 Resign")
                 }
             }
+            // Emoji tray — toggles on smiley tap, matches iOS
+            if (showEmojiTray) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    horizontalArrangement = Arrangement.SpaceEvenly
+                ) {
+                    listOf("😄", "😮", "👏", "🤔", "😅", "🎉").forEach { emoji ->
+                        IconButton(onClick = { onSendReaction(emoji); showEmojiTray = false }) {
+                            Text(emoji, fontSize = 28.sp)
+                        }
+                    }
+                }
+            }
         }
 
-        Spacer(modifier = Modifier.height(8.dp))
+        if (pendingReaction != null) {
+            Box(
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(pendingReaction, fontSize = 40.sp)
+            }
+        }
     }
 }

--- a/app/src/main/java/io/github/nicechester/omok/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/game/GameScreenViewModel.kt
@@ -21,6 +21,12 @@ class GameScreenViewModel(private val context: Context? = null) : ViewModel() {
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage
 
+    private val _pendingReaction = MutableStateFlow<String?>(null)
+    val pendingReaction: StateFlow<String?> = _pendingReaction
+
+    private var reactionClearJob: Job? = null
+    private var lastReactionTimestamp: Long = -1
+
     private val _remainingSeconds = MutableStateFlow<Int?>(null)
     val remainingSeconds: StateFlow<Int?> = _remainingSeconds
 
@@ -32,6 +38,21 @@ class GameScreenViewModel(private val context: Context? = null) : ViewModel() {
         viewModelScope.launch {
             GameRepository.currentRoom.collect { room ->
                 updateTimerState(room, force = false)
+                val reaction = room?.reaction
+                if (reaction != null && reaction.timestamp != lastReactionTimestamp) {
+                    val isFirstLoad = lastReactionTimestamp == -1L
+                    lastReactionTimestamp = reaction.timestamp
+                    if (!isFirstLoad) {
+                        _pendingReaction.value = reaction.emoji
+                        reactionClearJob?.cancel()
+                        reactionClearJob = viewModelScope.launch {
+                            delay(2500)
+                            _pendingReaction.value = null
+                        }
+                    }
+                } else if (reaction == null && lastReactionTimestamp == -1L) {
+                    lastReactionTimestamp = 0
+                }
             }
         }
     }
@@ -166,6 +187,12 @@ class GameScreenViewModel(private val context: Context? = null) : ViewModel() {
     fun rejectUndo() {
         viewModelScope.launch {
             try { GameRepository.rejectUndo() } catch (e: Exception) { _errorMessage.value = "Failed to reject undo: ${e.message}" }
+        }
+    }
+
+    fun sendReaction(emoji: String) {
+        viewModelScope.launch {
+            try { GameRepository.sendReaction(emoji) } catch (e: Exception) { /* silent */ }
         }
     }
 

--- a/app/src/main/java/io/github/nicechester/omok/ui/screens/GameScreen.kt
+++ b/app/src/main/java/io/github/nicechester/omok/ui/screens/GameScreen.kt
@@ -47,6 +47,7 @@ fun GameScreen(paddingValues: PaddingValues, viewModel: GameScreenViewModel? = n
     val resolvedViewModel: GameScreenViewModel = viewModel ?: viewModel { GameScreenViewModel(context) }
     val currentRoom = resolvedViewModel.currentRoom.collectAsState()
     val errorMessage by resolvedViewModel.errorMessage.collectAsState()
+    val pendingReaction by resolvedViewModel.pendingReaction.collectAsState()
 
     if (errorMessage != null) {
         AlertDialog(
@@ -89,7 +90,9 @@ fun GameScreen(paddingValues: PaddingValues, viewModel: GameScreenViewModel? = n
             onLeave = { resolvedViewModel.leaveGame() },
             onRequestUndo = { resolvedViewModel.requestUndo() },
             onApproveUndo = { resolvedViewModel.approveUndo() },
-            onRejectUndo = { resolvedViewModel.rejectUndo() }
+            onRejectUndo = { resolvedViewModel.rejectUndo() },
+            onSendReaction = { resolvedViewModel.sendReaction(it) },
+            pendingReaction = pendingReaction
         )
     } else {
         Box(


### PR DESCRIPTION
Closes #45

## Changes

- `GameRoom.kt` — added `Reaction` data class `{from, emoji, timestamp}`; added `reaction` field to `GameRoom`
- `GameRepository.kt` — added `sendReaction()` to write under `games/$gameId/reaction`; parse `reaction` node in `parseGameRoom()`
- `GameScreenViewModel.kt` — added `pendingReaction` state with 2.5s auto-clear; detects new reactions by comparing timestamp; skips stale reaction on first load
- `GameBoardScreen.kt` — smiley button toggles emoji tray (6 emojis, dismisses after send); reaction bubble displayed below action bar
- `GameScreen.kt` — wires `pendingReaction` and `onSendReaction` through to `GameBoardScreen`

## Interop
Same RTDB schema as iOS (nicechester/omok#92) — `reaction/{from, emoji, timestamp}` under `games/$gameId`. RTDB security rules already updated in the `omok` repo by PR #95.